### PR TITLE
Small fix install progress

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -29,7 +29,7 @@ setup(
     ext_modules=[Extension("eif",
                  sources=["_eif.pyx", "eif.cxx"],
                  include_dirs=[numpy.get_include()],
-                 extra_compile_args=['-Wcpp'],
+                 extra_compile_args=['-std=c++11', '-Wcpp'],
                  language="c++")],
     scripts=[],
     py_modules=['eif_old', 'version'],


### PR DESCRIPTION
One of the extra compile arguments in setup.py seemed to prevent successful installation on multiple systems. Simply removing this argument seems to resolve this with no negative implications. 
The argument seems to try and force the compiler to run in c++11. Unsure if this was even present on the tested systems