### PR TITLE
Fix compilation by using documented language keyword

### DIFF
--- a/_eif.pyx
+++ b/_eif.pyx
@@ -1,6 +1,6 @@
 # Cython wrapper for Extended Isolation Forest
 
-# distutils: language = C++
+# distutils: language = c++
 # distutils: sources  = eif.cxx
 # cython: language_level = 3
 


### PR DESCRIPTION
The [distutils](https://docs.python.org/3.9/distutils/apiref.html) API reference shows that the language should be specified as `c++`, not `C++`. Because of this seemingly trivial difference, builds failed with:

```
Error in compiling Cython file:
...
_eif.pyx:51:8: Operation only allowed in c++
```

Change the language to `c++` which makes this failure go away.